### PR TITLE
Add user dropdown menu with logout option

### DIFF
--- a/src/ui/CCP.UI/Layout/CCPLayout.razor
+++ b/src/ui/CCP.UI/Layout/CCPLayout.razor
@@ -6,6 +6,7 @@
 
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IUIUserContext UserContext
+@inject NavigationManager Navigation
 
 <HeadContent>
     <link rel="stylesheet" href="css/app.css" />
@@ -207,13 +208,25 @@
                 <span class="ccp-user-name">@UserContext.FullName</span>
                 <span class="ccp-user-role">@UserContext.Role</span>
             </div>
-            <button class="ccp-user-more" title="More options">
+            <button class="ccp-user-more" title="More options" @onclick="ToggleUserMenu">
                 <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
                     <circle cx="5" cy="12" r="1.5" />
                     <circle cx="12" cy="12" r="1.5" />
                     <circle cx="19" cy="12" r="1.5" />
                 </svg>
             </button>
+            @if (_isUserMenuOpen)
+            {
+                <div class="ccp-dropdown-overlay" @onclick="ToggleUserMenu"></div>
+                <div class="ccp-user-dropdown">
+                    <button class="ccp-user-dropdown-item" @onclick="LogoutAsync">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16">
+                            <path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4M16 17l5-5-5-5M21 12H9" />
+                        </svg>
+                        <span>Log Out</span>
+                    </button>
+                </div>
+            }
         </div>
 
     </aside>
@@ -295,11 +308,22 @@
 
 @code {
     private bool _isDarkMode = true;
+    private bool _isUserMenuOpen = false;
     private bool isLoading = false;
     private string? errorMessage = null;
 
     private void ToggleTheme()
     {
         _isDarkMode = !_isDarkMode;
+    }
+
+    private void ToggleUserMenu()
+    {
+        _isUserMenuOpen = !_isUserMenuOpen;
+    }
+
+    private async Task LogoutAsync()
+    {
+        Navigation.NavigateTo("/authentication/logout", forceLoad: true);
     }
 }

--- a/src/ui/CCP.UI/wwwroot/app.css
+++ b/src/ui/CCP.UI/wwwroot/app.css
@@ -313,6 +313,51 @@ a.ccp-nav-item.active .ccp-nav-icon {
         color: var(--ccp-text-mid);
     }
 
+/* User Dropdown */
+.ccp-user-dropdown {
+    position: absolute;
+    bottom: 60px;
+    left: 16px;
+    background: var(--ccp-surface-elevated, #1e1e1e);
+    border: 1px solid var(--ccp-border, #333);
+    border-radius: 8px;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+    padding: 8px;
+    min-width: 200px;
+    z-index: 1000;
+}
+
+.ccp-user-dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    padding: 10px 12px;
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    color: var(--ccp-text, #fff);
+    font-size: 14px;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.ccp-user-dropdown-item:hover{
+    background: var(--ccp-hover, rgba(255, 255, 255, 0.1));
+   }
+   
+   .ccp-user-dropdown-item svg {
+       flex-shrink: 0;
+   }
+.ccp-dropdown-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: transparent;
+    z-index: 999;
+}
 /*MAIN */
 .ccp-main {
     flex: 1;


### PR DESCRIPTION
Introduces a user dropdown menu in CCPLayout.razor, accessible via the "More options" button. The dropdown includes a "Log Out" action and closes when clicking outside or toggling the button. Adds related CSS for dropdown styling and overlay handling. Implements state management for menu visibility.