### PR TITLE
Feature: Add API Gateway with ticket detail and manager dashboard agg…

### DIFF
--- a/src/CCP.slnx
+++ b/src/CCP.slnx
@@ -25,6 +25,10 @@
     <Project Path="services/CustomerService/CustomerService.Infrastructure/CustomerService.Infrastructure.csproj" Id="89a63df1-ea30-49fd-a24e-79567250d400" />
     <Project Path="services/CustomerService/CustomerService.Sdk/CustomerService.Sdk.csproj" />
   </Folder>
+  <Folder Name="/src/services/Gateway/">
+    <Project Path="services/Gateway/Gateway.Api/Gateway.Api.csproj" />
+    <Project Path="services/Gateway/Gateway.Sdk/Gateway.Sdk.csproj" />
+  </Folder>
   <Folder Name="/src/services/EmailService/">
     <Project Path="services/EmailService/EmailService.API/EmailService.API.csproj" />
     <Project Path="services/EmailService/EmailService.Application/EmailService.Application.csproj" Id="96010c8e-4318-417b-9fa8-971c1c1f9699" />

--- a/src/apphost/CCP.AppHost/AppHost.cs
+++ b/src/apphost/CCP.AppHost/AppHost.cs
@@ -107,6 +107,7 @@ IResourceBuilder<ProjectResource> MessagingService = builder.AddProject<Projects
 IResourceBuilder<ProjectResource> ChatService = builder.AddProject<Projects.ChatService_Api>("chatservice-api");
 IResourceBuilder<ProjectResource> TicketService = builder.AddProject<Projects.TicketService_Api>("ticketservice-api");
 IResourceBuilder<ProjectResource> CustomerService = builder.AddProject<Projects.CustomerService_Api>("customerservice-api");
+IResourceBuilder<ProjectResource> Gateway = builder.AddProject<Projects.Gateway_Api>("ccp-gateway");
 IResourceBuilder<ProjectResource> CCPWebsite = builder.AddProject<Projects.CCP_Website>("ccp-website");
 IResourceBuilder<ProjectResource> UI = builder.AddProject<Projects.CCP_UI>("ccp-ui");
 IResourceBuilder<ProjectResource> EmailService = builder.AddProject<Projects.EmailService_API>("emailservice-api");
@@ -224,18 +225,38 @@ ChatService
     .WithOtlpExporter();
 
 
+Gateway
+    .WaitFor(Keycloak)
+    .WaitFor(TicketService)
+    .WaitFor(MessagingService)
+    .WaitFor(IdentityService)
+    .WithReference(Keycloak)
+    .WithReference(TicketService)
+    .WithReference(MessagingService)
+    .WithReference(IdentityService)
+    .WithEnvironment("CCP.ServiceAccount", ServiceAccountSecret)
+    .WithUrlForEndpoint("https", endpoint =>
+    {
+        endpoint.Url = "/swagger";
+        endpoint.DisplayLocation = UrlDisplayLocation.SummaryAndDetails;
+        endpoint.DisplayText = "API Swagger";
+    })
+    .WithOtlpExporter();
+
 UI.WaitFor(MessagingService)
   .WaitFor(Keycloak)
   .WaitFor(IdentityService)
   .WaitFor(CustomerService)
   .WaitFor(ChatService)
   .WaitFor(TicketService)
+  .WaitFor(Gateway)
   .WithReference(MessagingService)
   .WithReference(Keycloak)
   .WithReference(ChatService)
   .WithReference(CustomerService)
   .WithReference(IdentityService)
   .WithReference(TicketService)
+  .WithReference(Gateway)
   .WithEndpoint("https", endpoint => endpoint.IsProxied = false)
   .WithOtlpExporter();
 

--- a/src/apphost/CCP.AppHost/CCP.AppHost.csproj
+++ b/src/apphost/CCP.AppHost/CCP.AppHost.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\services\ChatService\ChatService.Api\ChatService.Api.csproj" />
     <ProjectReference Include="..\..\services\CustomerService\CustomerService.Api\CustomerService.Api.csproj" />
     <ProjectReference Include="..\..\services\IdentityService\IdentityService.API\IdentityService.API.csproj" />
+    <ProjectReference Include="..\..\services\Gateway\Gateway.Api\Gateway.Api.csproj" />
     <ProjectReference Include="..\..\services\MessagingService\MessagingService.Api\MessagingService.Api.csproj" />
     <ProjectReference Include="..\..\services\TicketService\TicketService.Api\TicketService.Api.csproj" />
     <ProjectReference Include="..\..\ui\CCP.UI\CCP.UI.csproj" />

--- a/src/services/Gateway/Gateway.Api/Docs/Gateway.Api.json
+++ b/src/services/Gateway/Gateway.Api/Docs/Gateway.Api.json
@@ -1,0 +1,331 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "Gateway.Api | v1",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/gateway/tickets/{ticketId}/detail": {
+      "get": {
+        "tags": [
+          "Gateway"
+        ],
+        "parameters": [
+          {
+            "name": "ticketId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TicketDetailAggregateDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gateway/dashboard/manager": {
+      "get": {
+        "tags": [
+          "Gateway"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagerDashboardAggregateDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ManagerDashboardAggregateDto": {
+        "type": "object",
+        "properties": {
+          "stats": {
+            "$ref": "#/components/schemas/ManagerStatsSdkDto"
+          },
+          "userNames": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ManagerStatsSdkDto": {
+        "type": "object",
+        "properties": {
+          "openTickets": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "closedToday": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "avgResponseTime": {
+            "type": "string"
+          },
+          "awaitingUser": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "teamPerformance": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SupporterPerformanceSdkDto"
+            }
+          }
+        }
+      },
+      "MessageDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "ticketId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "userId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "organizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "content": {
+            "type": "string"
+          },
+          "createdAtUtc": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "updatedAtUtc": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "isEdited": {
+            "type": "boolean"
+          },
+          "isDeleted": {
+            "type": "boolean"
+          },
+          "isInternalNote": {
+            "type": "boolean"
+          },
+          "deletedAtUtc": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "title": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "type": [
+              "null",
+              "integer"
+            ],
+            "format": "int32"
+          },
+          "detail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "instance": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "SupporterPerformanceSdkDto": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "resolvedCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "TicketDetailAggregateDto": {
+        "type": "object",
+        "properties": {
+          "ticket": {
+            "$ref": "#/components/schemas/TicketSdkDto"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MessageDto"
+            }
+          },
+          "userNames": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "TicketSdkDto": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "organizationId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "customerId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "date-time"
+          },
+          "assignedUserId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          },
+          "assignedByUserId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "type": "http",
+        "description": "JWT",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  },
+  "security": [
+    {
+      "Bearer": [ ]
+    }
+  ],
+  "tags": [
+    {
+      "name": "Gateway"
+    }
+  ]
+}

--- a/src/services/Gateway/Gateway.Api/Dtos/ManagerDashboardAggregateDto.cs
+++ b/src/services/Gateway/Gateway.Api/Dtos/ManagerDashboardAggregateDto.cs
@@ -1,0 +1,10 @@
+using TicketService.Sdk.Dtos;
+
+namespace Gateway.Api.Dtos
+{
+    public class ManagerDashboardAggregateDto
+    {
+        public ManagerStatsSdkDto Stats { get; set; } = new();
+        public Dictionary<string, string> UserNames { get; set; } = new();
+    }
+}

--- a/src/services/Gateway/Gateway.Api/Dtos/TicketDetailAggregateDto.cs
+++ b/src/services/Gateway/Gateway.Api/Dtos/TicketDetailAggregateDto.cs
@@ -1,0 +1,12 @@
+using MessagingService.Sdk.Dtos;
+using TicketService.Sdk.Dtos;
+
+namespace Gateway.Api.Dtos
+{
+    public class TicketDetailAggregateDto
+    {
+        public TicketSdkDto Ticket { get; set; } = default!;
+        public List<MessageDto> Messages { get; set; } = new();
+        public Dictionary<string, string> UserNames { get; set; } = new();
+    }
+}

--- a/src/services/Gateway/Gateway.Api/Endpoints/GatewayEndpoints.cs
+++ b/src/services/Gateway/Gateway.Api/Endpoints/GatewayEndpoints.cs
@@ -1,0 +1,138 @@
+using Gateway.Api.Dtos;
+using IdentityService.Sdk.Services.User;
+using MessagingService.Sdk.Services;
+using TicketService.Sdk.Services.Ticket;
+
+namespace Gateway.Api.Endpoints
+{
+    public static class GatewayEndpoints
+    {
+        public static IEndpointRouteBuilder MapGatewayEndpoints(this IEndpointRouteBuilder builder)
+        {
+            var group = builder.MapGroup("/gateway")
+                               .WithTags("Gateway")
+                               .RequireAuthorization();
+
+            group.MapGet("/tickets/{ticketId:int}/detail", GetTicketDetail)
+                 .Produces<TicketDetailAggregateDto>(StatusCodes.Status200OK)
+                 .ProducesProblem(StatusCodes.Status404NotFound)
+                 .ProducesProblem(StatusCodes.Status500InternalServerError);
+
+            group.MapGet("/dashboard/manager", GetManagerDashboard)
+                 .Produces<ManagerDashboardAggregateDto>(StatusCodes.Status200OK)
+                 .ProducesProblem(StatusCodes.Status500InternalServerError);
+
+            return builder;
+        }
+
+        private static async Task<IResult> GetTicketDetail(
+            int ticketId,
+            ITicketService ticketService,
+            IMessageSdkService messagingService,
+            IUserService userService,
+            ILogger<Program> logger,
+            CancellationToken ct)
+        {
+            try
+            {
+                var ticketResult = await ticketService.GetTicket(ticketId, ct);
+                if (!ticketResult.IsSuccess)
+                    return ticketResult.ToProblemDetails();
+
+                var ticket = ticketResult.Value;
+
+                var messagesResult = await messagingService.GetMessagesByTicketIdAsync(ticketId, cancellationToken: ct);
+                var messages = messagesResult.IsSuccess ? messagesResult.Value.Items.ToList() : new();
+
+                var userIds = new HashSet<Guid>();
+                if (ticket.CustomerId.HasValue) userIds.Add(ticket.CustomerId.Value);
+                if (ticket.AssignedUserId.HasValue) userIds.Add(ticket.AssignedUserId.Value);
+                foreach (var m in messages)
+                    if (m.UserId.HasValue && m.UserId.Value != Guid.Empty)
+                        userIds.Add(m.UserId.Value);
+
+                var nameTasks = userIds.Select(async id =>
+                {
+                    try
+                    {
+                        var r = await userService.GetUserDetailsAsync(id, ct);
+                        return (id, name: r.IsSuccess ? r.Value.name : (string?)null);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning(ex, "Could not resolve user name for {UserId}", id);
+                        return (id, name: (string?)null);
+                    }
+                });
+
+                var nameResults = await Task.WhenAll(nameTasks);
+                var userNames = nameResults
+                    .Where(r => r.name is not null)
+                    .ToDictionary(r => r.id.ToString(), r => r.name!);
+
+                return Results.Ok(new TicketDetailAggregateDto
+                {
+                    Ticket = ticket,
+                    Messages = messages,
+                    UserNames = userNames
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error building ticket detail aggregate for ticket {TicketId}", ticketId);
+                return Results.Problem("An error occurred while building ticket detail.");
+            }
+        }
+
+        private static async Task<IResult> GetManagerDashboard(
+            ITicketService ticketService,
+            IUserService userService,
+            ILogger<Program> logger,
+            CancellationToken ct)
+        {
+            try
+            {
+                var statsResult = await ticketService.GetManagerStatsAsync(ct);
+                if (!statsResult.IsSuccess)
+                    return statsResult.ToProblemDetails();
+
+                var stats = statsResult.Value;
+
+                var userIds = stats.TeamPerformance
+                    .Select(p => p.UserId)
+                    .Distinct()
+                    .ToList();
+
+                var nameTasks = userIds.Select(async id =>
+                {
+                    try
+                    {
+                        var r = await userService.GetUserDetailsAsync(id, ct);
+                        return (id, name: r.IsSuccess ? r.Value.name : (string?)null);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning(ex, "Could not resolve user name for {UserId}", id);
+                        return (id, name: (string?)null);
+                    }
+                });
+
+                var nameResults = await Task.WhenAll(nameTasks);
+                var userNames = nameResults
+                    .Where(r => r.name is not null)
+                    .ToDictionary(r => r.id.ToString(), r => r.name!);
+
+                return Results.Ok(new ManagerDashboardAggregateDto
+                {
+                    Stats = stats,
+                    UserNames = userNames
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error building manager dashboard aggregate");
+                return Results.Problem("An error occurred while building manager dashboard.");
+            }
+        }
+    }
+}

--- a/src/services/Gateway/Gateway.Api/Gateway.Api.csproj
+++ b/src/services/Gateway/Gateway.Api/Gateway.Api.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>d3e5f7a1-2b4c-4d8e-9f0a-1b2c3d4e5f6a</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\apphost\CCP.ServiceDefaults\CCP.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\..\shared\CCP.Shared\CCP.Shared.csproj" />
+    <ProjectReference Include="..\..\..\services\IdentityService\IdentityService.Sdk\IdentityService.Sdk.csproj" />
+    <ProjectReference Include="..\..\..\services\MessagingService\MessagingService.Sdk\MessagingService.Sdk.csproj" />
+    <ProjectReference Include="..\..\..\services\TicketService\TicketService.Sdk\TicketService.Sdk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Docs\" />
+  </ItemGroup>
+
+</Project>

--- a/src/services/Gateway/Gateway.Api/GlobalUsing.cs
+++ b/src/services/Gateway/Gateway.Api/GlobalUsing.cs
@@ -1,0 +1,6 @@
+global using CCP.ServiceDefaults.Extensions;
+global using CCP.ServiceDefaults.Startup;
+global using CCP.ServiceDefaults.swagger;
+global using CCP.Shared.AuthContext;
+global using CCP.Shared.ResultAbstraction;
+global using CCP.Shared.ValueObjects;

--- a/src/services/Gateway/Gateway.Api/Program.cs
+++ b/src/services/Gateway/Gateway.Api/Program.cs
@@ -1,0 +1,73 @@
+using System.Reflection;
+using Gateway.Api.Endpoints;
+using IdentityService.Sdk.ServiceDefaults;
+using MessagingService.Sdk.ServiceDefaults;
+using TicketService.Sdk.ServiceDefaults;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAuthentication();
+builder.Services.AddAuthorization();
+builder.Services.AddHttpContextAccessor();
+builder.Services.ConfigureDefaultOpenTelemetry("Gateway.Api");
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddOpenApi(options =>
+{
+    OpenApiConfiguration.SetupOpenApiForSwagger(options);
+});
+
+if (Assembly.GetEntryAssembly()?.GetName().Name != "GetDocument.Insider")
+{
+    var keycloakURL = builder.Configuration.GetValue<string>("services:Keycloak:http:0")
+        ?? throw new InvalidOperationException("KeycloakServiceUrl configuration value is required.");
+    builder.Services.AddApiAuthenticationServices("Gateway.Api", "CCP", keycloakURL);
+
+    builder.Services.AddSwaggerGen(c => { SetupSwagger.SetupSwaggerForChatApp(c); });
+}
+
+builder.Services.AddTicketServiceSdk(
+    builder.Configuration.GetConnectionString("ticketservice-api")
+        ?? builder.Configuration["services:ticketservice-api:https:0"]
+        ?? string.Empty,
+    IsServiceAccount: true,
+    configuration: builder.Configuration);
+
+builder.Services.AddMessageServiceSDK(
+    builder.Configuration.GetConnectionString("messagingservice-api")
+        ?? builder.Configuration["services:messagingservice-api:http:0"]
+        ?? string.Empty,
+    IsServiceAccount: true,
+    configuration: builder.Configuration);
+
+builder.Services.AddIdentityServiceSdk(
+    builder.Configuration.GetConnectionString("identityservice-api")
+        ?? builder.Configuration["services:identityservice-api:http:0"]
+        ?? string.Empty,
+    IsServiceAccount: true,
+    configuration: builder.Configuration);
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+if (Assembly.GetEntryAssembly()?.GetName().Name != "GetDocument.Insider")
+{
+    app.AppMapSwaggerExtensions();
+    app.UseMiddleware<AuthMiddleware>();
+}
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.UseHttpsRedirection();
+app.MapGatewayEndpoints();
+
+app.Run();
+
+namespace TestProgramNameSpace
+{
+    public partial class Program { }
+}

--- a/src/services/Gateway/Gateway.Api/Properties/launchSettings.json
+++ b/src/services/Gateway/Gateway.Api/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Gateway.Api": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:56574;http://localhost:56575"
+    }
+  }
+}

--- a/src/services/Gateway/Gateway.Sdk/Dtos/ManagerDashboardAggregateSdkDto.cs
+++ b/src/services/Gateway/Gateway.Sdk/Dtos/ManagerDashboardAggregateSdkDto.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+using TicketService.Sdk.Dtos;
+
+namespace Gateway.Sdk.Dtos
+{
+    public class ManagerDashboardAggregateSdkDto
+    {
+        [JsonPropertyName("stats")]
+        public ManagerStatsSdkDto Stats { get; set; } = new();
+
+        [JsonPropertyName("userNames")]
+        public Dictionary<string, string> UserNames { get; set; } = new();
+    }
+}

--- a/src/services/Gateway/Gateway.Sdk/Dtos/TicketDetailAggregateSdkDto.cs
+++ b/src/services/Gateway/Gateway.Sdk/Dtos/TicketDetailAggregateSdkDto.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+using MessagingService.Sdk.Dtos;
+using TicketService.Sdk.Dtos;
+
+namespace Gateway.Sdk.Dtos
+{
+    public class TicketDetailAggregateSdkDto
+    {
+        [JsonPropertyName("ticket")]
+        public TicketSdkDto Ticket { get; set; } = default!;
+
+        [JsonPropertyName("messages")]
+        public List<MessageDto> Messages { get; set; } = new();
+
+        [JsonPropertyName("userNames")]
+        public Dictionary<string, string> UserNames { get; set; } = new();
+    }
+}

--- a/src/services/Gateway/Gateway.Sdk/Gateway.Sdk.csproj
+++ b/src/services/Gateway/Gateway.Sdk/Gateway.Sdk.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\shared\CCP.Sdk.utils\CCP.Sdk.utils.csproj" />
+    <ProjectReference Include="..\..\..\shared\CCP.Shared\CCP.Shared.csproj" />
+    <ProjectReference Include="..\..\..\services\MessagingService\MessagingService.Sdk\MessagingService.Sdk.csproj" />
+    <ProjectReference Include="..\..\..\services\TicketService\TicketService.Sdk\TicketService.Sdk.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/services/Gateway/Gateway.Sdk/GlobalUsing.cs
+++ b/src/services/Gateway/Gateway.Sdk/GlobalUsing.cs
@@ -1,0 +1,4 @@
+global using CCP.Sdk.utils.Abstractions;
+global using CCP.Sdk.utils.Authentication;
+global using CCP.Shared.ResultAbstraction;
+global using Microsoft.Extensions.DependencyInjection;

--- a/src/services/Gateway/Gateway.Sdk/ServiceDefaults/ServiceRegistration.cs
+++ b/src/services/Gateway/Gateway.Sdk/ServiceDefaults/ServiceRegistration.cs
@@ -1,0 +1,17 @@
+using Gateway.Sdk.Services;
+using Microsoft.Extensions.Configuration;
+
+namespace Gateway.Sdk.ServiceDefaults
+{
+    public static class ServiceRegistration
+    {
+        private const string ClientName = "GatewayServiceClient";
+
+        public static IServiceCollection AddGatewayServiceSdk(this IServiceCollection services, string serviceUrl, bool IsServiceAccount = false, IConfiguration? configuration = null)
+        {
+            services.AddSdkAuthentication(ClientName, serviceUrl, IsServiceAccount, configuration);
+            services.AddScoped<IGatewayService, GatewayApiClientService>();
+            return services;
+        }
+    }
+}

--- a/src/services/Gateway/Gateway.Sdk/Services/GatewayApiClientService.cs
+++ b/src/services/Gateway/Gateway.Sdk/Services/GatewayApiClientService.cs
@@ -1,0 +1,79 @@
+using System.Net.Http.Json;
+using Gateway.Sdk.Dtos;
+using Microsoft.Extensions.Logging;
+
+namespace Gateway.Sdk.Services
+{
+    internal class GatewayApiClientService : IGatewayService
+    {
+        private const string ClientName = "GatewayServiceClient";
+
+        private readonly ILogger<GatewayApiClientService> _logger;
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public GatewayApiClientService(ILogger<GatewayApiClientService> logger, IHttpClientFactory httpClientFactory)
+        {
+            _logger = logger;
+            _httpClientFactory = httpClientFactory;
+        }
+
+        public async Task<Result<TicketDetailAggregateSdkDto>> GetTicketDetailAsync(int ticketId, CancellationToken ct = default)
+        {
+            try
+            {
+                var httpClient = _httpClientFactory.CreateClient(ClientName);
+                var response = await httpClient.GetAsync($"/gateway/tickets/{ticketId}/detail", ct);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    return response.StatusCode switch
+                    {
+                        System.Net.HttpStatusCode.NotFound => Result.Failure<TicketDetailAggregateSdkDto>(Error.NotFound("NotFound", $"Ticket {ticketId} was not found.")),
+                        System.Net.HttpStatusCode.Unauthorized => Result.Failure<TicketDetailAggregateSdkDto>(Error.Failure("Unauthorized", "You are not authorized.")),
+                        System.Net.HttpStatusCode.Forbidden => Result.Failure<TicketDetailAggregateSdkDto>(Error.Failure("Forbidden", "You do not have permission.")),
+                        _ => Result.Failure<TicketDetailAggregateSdkDto>(Error.Failure("GatewayError", $"Gateway returned status {(int)response.StatusCode}."))
+                    };
+                }
+
+                var dto = await response.Content.ReadFromJsonAsync<TicketDetailAggregateSdkDto>(cancellationToken: ct);
+                return dto is not null
+                    ? Result.Success(dto)
+                    : Result.Failure<TicketDetailAggregateSdkDto>(Error.Failure("GatewayError", "Gateway returned an empty response."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error fetching ticket detail for ticket {TicketId}", ticketId);
+                return Result.Failure<TicketDetailAggregateSdkDto>(Error.Failure("GatewayError", "An error occurred while fetching ticket detail."));
+            }
+        }
+
+        public async Task<Result<ManagerDashboardAggregateSdkDto>> GetManagerDashboardAsync(CancellationToken ct = default)
+        {
+            try
+            {
+                var httpClient = _httpClientFactory.CreateClient(ClientName);
+                var response = await httpClient.GetAsync("/gateway/dashboard/manager", ct);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    return response.StatusCode switch
+                    {
+                        System.Net.HttpStatusCode.Unauthorized => Result.Failure<ManagerDashboardAggregateSdkDto>(Error.Failure("Unauthorized", "You are not authorized.")),
+                        System.Net.HttpStatusCode.Forbidden => Result.Failure<ManagerDashboardAggregateSdkDto>(Error.Failure("Forbidden", "You do not have permission.")),
+                        _ => Result.Failure<ManagerDashboardAggregateSdkDto>(Error.Failure("GatewayError", $"Gateway returned status {(int)response.StatusCode}."))
+                    };
+                }
+
+                var dto = await response.Content.ReadFromJsonAsync<ManagerDashboardAggregateSdkDto>(cancellationToken: ct);
+                return dto is not null
+                    ? Result.Success(dto)
+                    : Result.Failure<ManagerDashboardAggregateSdkDto>(Error.Failure("GatewayError", "Gateway returned an empty response."));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error fetching manager dashboard");
+                return Result.Failure<ManagerDashboardAggregateSdkDto>(Error.Failure("GatewayError", "An error occurred while fetching manager dashboard."));
+            }
+        }
+    }
+}

--- a/src/services/Gateway/Gateway.Sdk/Services/IGatewayService.cs
+++ b/src/services/Gateway/Gateway.Sdk/Services/IGatewayService.cs
@@ -1,0 +1,10 @@
+using Gateway.Sdk.Dtos;
+
+namespace Gateway.Sdk.Services
+{
+    public interface IGatewayService
+    {
+        Task<Result<TicketDetailAggregateSdkDto>> GetTicketDetailAsync(int ticketId, CancellationToken ct = default);
+        Task<Result<ManagerDashboardAggregateSdkDto>> GetManagerDashboardAsync(CancellationToken ct = default);
+    }
+}

--- a/src/services/IdentityService/IdentityService.Sdk/ServiceDefaults/ServiceRegistration.cs
+++ b/src/services/IdentityService/IdentityService.Sdk/ServiceDefaults/ServiceRegistration.cs
@@ -5,6 +5,7 @@ using IdentityService.Sdk.Services.Supporter;
 using IdentityService.Sdk.Services.Tenant;
 using IdentityService.Sdk.Services.User;
 using IdentityService.Sdk.Services.UserRights;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace IdentityService.Sdk.ServiceDefaults
@@ -13,9 +14,9 @@ namespace IdentityService.Sdk.ServiceDefaults
     {
         private const string IdentityServiceClientName = "IdentityServiceClient";
 
-        public static IServiceCollection AddIdentityServiceSdk(this IServiceCollection services, string serviceUrl, bool IsServiceAccount = false)
+        public static IServiceCollection AddIdentityServiceSdk(this IServiceCollection services, string serviceUrl, bool IsServiceAccount = false, IConfiguration ? configuration = null)
         {
-            services.AddSdkAuthentication(IdentityServiceClientName, serviceUrl, IsServiceAccount);
+            services.AddSdkAuthentication(IdentityServiceClientName, serviceUrl, IsServiceAccount, configuration);
 
             services.AddScoped<IKiotaApiClient<IdentityServiceClient>>(sp =>
             {

--- a/src/services/MessagingService/MessagingService.Sdk/ServiceDefaults/ServiceRegistration.cs
+++ b/src/services/MessagingService/MessagingService.Sdk/ServiceDefaults/ServiceRegistration.cs
@@ -1,4 +1,5 @@
 ﻿using MessagingService.Sdk.Services;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MessagingService.Sdk.ServiceDefaults
@@ -7,9 +8,9 @@ namespace MessagingService.Sdk.ServiceDefaults
     {
         private const string ServiceName = "MessageService";
 
-        public static IServiceCollection AddMessageServiceSDK(this IServiceCollection services, string serviceUrl, bool IsServiceAccount = false)
+        public static IServiceCollection AddMessageServiceSDK(this IServiceCollection services, string serviceUrl, bool IsServiceAccount = false, IConfiguration? configuration = null)
         {
-            services.AddSdkAuthentication(ServiceName, serviceUrl, IsServiceAccount);
+            services.AddSdkAuthentication(ServiceName, serviceUrl, IsServiceAccount, configuration);
 
             services.AddScoped<IKiotaApiClient<MessagingServiceClient>>(sp =>
             {

--- a/src/services/TicketService/TicketService.Infrastructure/Persistence/TicketDbContext.cs
+++ b/src/services/TicketService/TicketService.Infrastructure/Persistence/TicketDbContext.cs
@@ -19,7 +19,7 @@ namespace TicketService.Infrastructure.Persistence
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.Entity<Ticket>().HasQueryFilter(t => t.OrganizationId == _currentUser.OrganizationId);
+            modelBuilder.Entity<Ticket>().HasQueryFilter(t => _currentUser.IsServiceAccount || t.OrganizationId == _currentUser.OrganizationId);
             modelBuilder.ApplyConfiguration<Ticket>(new TicketEntityConfiguration());
             modelBuilder.ApplyConfiguration<Assignment>(new AssignmentEntityConfiguration());
             modelBuilder.ApplyConfiguration<TicketHistoryEntry>(new TicketHistoryEntryConfiguration());

--- a/src/services/TicketService/TicketService.Infrastructure/Persistence/TicketDbContextFactory.cs
+++ b/src/services/TicketService/TicketService.Infrastructure/Persistence/TicketDbContextFactory.cs
@@ -21,10 +21,13 @@ namespace TicketService.Infrastructure.Persistence
 
         private class DesignTimeCurrentUser : ICurrentUser
         {
-            public Guid UserId => Guid.Empty;
-            public Guid OrganizationId => Guid.Empty;
-            public void SetCurrentUser(Guid userId) { }
-            public void SetOrganizationId(Guid organizationId) { }
+            public Guid UserId { get; private set; }
+            public Guid OrganizationId { get; private set; }
+            public bool IsServiceAccount { get; private set; }
+
+            public void SetCurrentUser(Guid userId) => UserId = userId;
+            public void SetOrganizationId(Guid organizationId) => OrganizationId = organizationId;
+            public void SetIsServiceAccount(bool isServiceAccount) => IsServiceAccount = isServiceAccount;
         }
     }
 }

--- a/src/shared/CCP.Shared/AuthContext/AuthMiddleware.cs
+++ b/src/shared/CCP.Shared/AuthContext/AuthMiddleware.cs
@@ -23,8 +23,10 @@ namespace CCP.Shared.AuthContext
                 {
                     userContext.SetCurrentUser(Guid.Parse(userIdClaim.Value));
                 }
+
                 var orgIdClaim = context.User.Claims.FirstOrDefault(c => c.Type == "org")
                             ?? context.User.Claims.FirstOrDefault(c => c.Type == "organization");
+
                 if (orgIdClaim != null)
                 {
                     Dictionary<string, Dictionary<string, string>>? orgData = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, Dictionary<string, string>>>(orgIdClaim.Value);
@@ -36,7 +38,13 @@ namespace CCP.Shared.AuthContext
                         }
                     }
                 }
+                else
+                {
+                    // No org claim means this is a service account token
+                    userContext.SetIsServiceAccount(true);
+                }
             }
+
             await _next(context);
         }
     }

--- a/src/shared/CCP.Shared/AuthContext/CurrentUser.cs
+++ b/src/shared/CCP.Shared/AuthContext/CurrentUser.cs
@@ -3,17 +3,11 @@
     public class CurrentUser : ICurrentUser
     {
         public Guid UserId { get; private set; }
-
         public Guid OrganizationId { get; private set; }
+        public bool IsServiceAccount { get; private set; }
 
-        public void SetCurrentUser(Guid userId)
-        {
-            UserId = userId;
-        }
-
-        public void SetOrganizationId(Guid organizationId)
-        {
-            OrganizationId = organizationId;
-        }
+        public void SetCurrentUser(Guid userId) => UserId = userId;
+        public void SetOrganizationId(Guid organizationId) => OrganizationId = organizationId;
+        public void SetIsServiceAccount(bool isServiceAccount) => IsServiceAccount = isServiceAccount;
     }
 }

--- a/src/shared/CCP.Shared/AuthContext/ICurrentUser.cs
+++ b/src/shared/CCP.Shared/AuthContext/ICurrentUser.cs
@@ -4,8 +4,10 @@
     {
         Guid UserId { get; }
         Guid OrganizationId { get; }
+        bool IsServiceAccount { get; }
 
         void SetCurrentUser(Guid userId);
         void SetOrganizationId(Guid organizationId);
+        void SetIsServiceAccount(bool isServiceAccount);
     }
 }

--- a/src/tests/UI/CPP.UI.Tests/Fixtures/Application/TestFactoryApplication.cs
+++ b/src/tests/UI/CPP.UI.Tests/Fixtures/Application/TestFactoryApplication.cs
@@ -3,6 +3,7 @@ using CCP.Shared.UIContext;
 using CCP.UI.Services;
 using CPP.UI.Tests.Fixtures.Website;
 using CPP.UI.Tests.Utils;
+using Gateway.Sdk.Services;
 using IdentityService.Sdk.Services.Customer;
 using IdentityService.Sdk.Services.Supporter;
 using IdentityService.Sdk.Services.Tenant;
@@ -45,6 +46,7 @@ namespace CPP.UI.Tests.Fixtures.Application
                     ["services:messagingservice-api:http:0"] = "http://localhost:5005",
                     ["services:EmailService:http:0"] = "http://localhost:5006",
                     ["services:chatservice-api:http:0"] = "http://localhost:5007",
+                    ["services:ccp-gateway:http:0"] = "http://localhost:5008",
                     ["CircuitOptions.DetailedErrors"] = "true",
                     ["UI_TESTS"] = "true"
                 })
@@ -63,6 +65,9 @@ namespace CPP.UI.Tests.Fixtures.Application
             AddMockedScoped<ChatHubService>(services);
             AddMockedScoped<ICurrentUser>(services);
             AddMockedScoped<IUIUserContext>(services);
+
+            //API Gateway
+            AddMockedScoped<IGatewayService>(services);
 
             // MessagingService Sdk
             AddMockedScoped<IMessageSdkService>(services);

--- a/src/ui/CCP.UI/CCP.UI.csproj
+++ b/src/ui/CCP.UI/CCP.UI.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\apphost\CCP.ServiceDefaults\CCP.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\..\services\Gateway\Gateway.Sdk\Gateway.Sdk.csproj" />
     <ProjectReference Include="..\..\services\ChatService\ChatService.Sdk\ChatService.Sdk.csproj" />
     <ProjectReference Include="..\..\services\CustomerService\CustomerService.Sdk\CustomerService.Sdk.csproj" />
     <ProjectReference Include="..\..\services\IdentityService\IdentityService.Sdk\IdentityService.Sdk.csproj" />

--- a/src/ui/CCP.UI/Components/Dashboard/SaasDashboardManager.razor
+++ b/src/ui/CCP.UI/Components/Dashboard/SaasDashboardManager.razor
@@ -195,7 +195,7 @@
                 var maxCount = _stats.TeamPerformance.Max(p => p.ResolvedCount);
                 @foreach (var supporter in _stats.TeamPerformance)
                 {
-                    var name = _supporterNames.TryGetValue(supporter.UserId, out var n) ? n : supporter.UserId.ToString()[..8] + "…";
+                    var name = GetSupporterName(supporter.UserId);
                     var barWidth = maxCount > 0 ? (int)((supporter.ResolvedCount / (double)maxCount) * 100) : 0;
                     <div class="dash-team-row">
                         <div class="dash-feed-avatar" style="background:linear-gradient(135deg,#6366f1,#8b5cf6)">

--- a/src/ui/CCP.UI/Components/Dashboard/SaasDashboardManager.razor.cs
+++ b/src/ui/CCP.UI/Components/Dashboard/SaasDashboardManager.razor.cs
@@ -1,6 +1,6 @@
+using Gateway.Sdk.Services;
 using CCP.Shared.UIContext;
 using CCP.Shared.ValueObjects;
-using IdentityService.Sdk.Services.User;
 using Microsoft.AspNetCore.Components;
 using TicketService.Sdk.Dtos;
 using TicketService.Sdk.Services.Ticket;
@@ -10,54 +10,36 @@ namespace CCP.UI.Components.Dashboard;
 public partial class SaasDashboardManager : ComponentBase
 {
     [Inject] private ITicketService TicketService { get; set; } = default!;
-    [Inject] private IUserService UserService { get; set; } = default!;
+    [Inject] private IGatewayService GatewayService { get; set; } = default!;
     [Inject] private IUIUserContext UserContext { get; set; } = default!;
     [Inject] private ILogger<SaasDashboardManager> Logger { get; set; } = default!;
     [Inject] private NavigationManager Navigation { get; set; } = default!;
 
     private ManagerStatsSdkDto? _stats;
     private List<TicketHistoryEntryDto>? _feedEntries;
-    private Dictionary<Guid, string> _supporterNames = new();
+    private Dictionary<string, string> _supporterNames = new();
 
     protected override async Task OnInitializedAsync()
     {
         if (!RendererInfo.IsInteractive)
             return;
-        await LoadStatsAsync();
+        await Task.WhenAll(LoadDashboardAsync(), LoadFeedAsync());
     }
 
-    private async Task LoadStatsAsync()
+    private async Task LoadDashboardAsync()
     {
-        var result = await TicketService.GetManagerStatsAsync();
-        if (result.IsSuccess && result.Value is not null)
-            _stats = result.Value;
-        else
-            Logger.LogError("Failed to load manager stats: {Code} - {Description}",
-                result.Error.Code, result.Error.Description);
-        StateHasChanged();
-
-        var feedTask = LoadFeedAsync();
-
-        if (_stats?.TeamPerformance?.Any() == true)
+        var result = await GatewayService.GetManagerDashboardAsync();
+        if (result.IsSuccess)
         {
-            var nameTasks = _stats.TeamPerformance.Select(async p =>
-            {
-                try
-                {
-                    var result = await UserService.GetUserDetailsAsync(p.UserId);
-                    return (p.UserId, name: result.IsSuccess ? result.Value.name : p.UserId.ToString()[..8] + "…");
-                }
-                catch
-                {
-                    return (p.UserId, name: p.UserId.ToString()[..8] + "…");
-                }
-            });
-            var nameResults = await Task.WhenAll(nameTasks);
-            _supporterNames = nameResults.ToDictionary(r => r.UserId, r => r.name);
-            StateHasChanged();
+            _stats = result.Value.Stats;
+            _supporterNames = result.Value.UserNames;
         }
-
-        await feedTask;
+        else
+        {
+            Logger.LogError("Failed to load manager dashboard: {Code} - {Description}",
+                result.Error.Code, result.Error.Description);
+        }
+        await InvokeAsync(StateHasChanged);
     }
 
     private async Task LoadFeedAsync()
@@ -68,7 +50,7 @@ public partial class SaasDashboardManager : ComponentBase
         else
             Logger.LogError("SaasDashboardManager failed to load org history: {Error}", result.Error);
 
-        StateHasChanged();
+        await InvokeAsync(StateHasChanged);
     }
 
     private void NavigateToTicket(int ticketId) =>
@@ -133,6 +115,13 @@ public partial class SaasDashboardManager : ComponentBase
         if (diff.TotalHours < 24) return $"{(int)diff.TotalHours} hrs ago";
         if (diff.TotalDays < 2) return "Yesterday";
         return $"{(int)diff.TotalDays} days ago";
+    }
+
+    private string GetSupporterName(Guid userId)
+    {
+        var key = userId.ToString();
+        if (_supporterNames.TryGetValue(key, out var name)) return name;
+        return userId.ToString()[..8] + "…";
     }
 
     private static string GetInitials(string name)

--- a/src/ui/CCP.UI/Components/TicketDetailComponents/TicketDetailManager.razor.cs
+++ b/src/ui/CCP.UI/Components/TicketDetailComponents/TicketDetailManager.razor.cs
@@ -1,4 +1,5 @@
-﻿using CCP.Shared.UIContext;
+using Gateway.Sdk.Services;
+using CCP.Shared.UIContext;
 using CCP.Shared.ValueObjects;
 using CCP.UI.Services;
 using IdentityService.Sdk.Models;
@@ -20,6 +21,7 @@ public partial class TicketDetailManager : ComponentBase, IAsyncDisposable
     [Inject] private ITicketService TicketService { get; set; } = default!;
     [Inject] private IAssignmentService AssignmentService { get; set; } = default!;
     [Inject] private IUserService UserService { get; set; } = default!;
+    [Inject] private IGatewayService GatewayService { get; set; } = default!;
     [Inject] private ILogger<TicketDetailManager> Logger { get; set; } = default!;
     [Inject] private NavigationManager NavigationManager { get; set; } = default!;
 
@@ -51,26 +53,28 @@ public partial class TicketDetailManager : ComponentBase, IAsyncDisposable
         HubService.OnMessageUpdated += HandleMessageUpdated;
         HubService.OnMessageDeleted += HandleMessageDeleted;
 
-        if (Ticket.CustomerId.HasValue)
-            _ = ResolveCustomerNameAsync(Ticket.CustomerId.Value);
-
-        await LoadMessagesAsync();
+        await LoadDetailAsync();
         _ = ConnectHubAsync();
     }
 
-    private async Task LoadMessagesAsync()
+    private async Task LoadDetailAsync()
     {
         _isLoadingMessages = true;
 
-        var result = await MessageSdkService.GetMessagesByTicketIdAsync(Ticket.Id);
-        if (result.IsSuccess && result.Value is not null)
+        var result = await GatewayService.GetTicketDetailAsync(Ticket.Id);
+        if (result.IsSuccess)
         {
-            _messages = result.Value.Items.ToList();
-            await ResolveUserNamesAsync(_messages);
+            _messages = result.Value.Messages;
+            foreach (var (key, name) in result.Value.UserNames)
+                if (Guid.TryParse(key, out var id))
+                    _userNameCache[id] = name;
+
+            if (Ticket.CustomerId.HasValue && _userNameCache.TryGetValue(Ticket.CustomerId.Value, out var customerName))
+                _customerName = customerName;
         }
         else
         {
-            Logger.LogError("TicketDetailManager failed to load messages for ticket {TicketId}: {Error}", Ticket.Id, result.Error);
+            Logger.LogError("TicketDetailManager failed to load detail for ticket {TicketId}: {Error}", Ticket.Id, result.Error);
         }
 
         _isLoadingMessages = false;
@@ -87,20 +91,6 @@ public partial class TicketDetailManager : ComponentBase, IAsyncDisposable
 
         if (HubService.IsConnected)
             _ = HubService.JoinTicketGroupAsync(Ticket.Id);
-    }
-
-    private async Task ResolveCustomerNameAsync(Guid customerId)
-    {
-        try
-        {
-            var result = await UserService.GetUserDetailsAsync(customerId);
-            _customerName = result.IsSuccess ? result.Value.name : null;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Could not resolve customer name for {CustomerId}", customerId);
-        }
-        await InvokeAsync(StateHasChanged);
     }
 
     private async Task SendMessageAsync()

--- a/src/ui/CCP.UI/Components/TicketDetailComponents/TicketDetailSupporter.razor.cs
+++ b/src/ui/CCP.UI/Components/TicketDetailComponents/TicketDetailSupporter.razor.cs
@@ -1,4 +1,5 @@
-﻿using CCP.Shared.UIContext;
+using Gateway.Sdk.Services;
+using CCP.Shared.UIContext;
 using CCP.Shared.ValueObjects;
 using CCP.UI.Services;
 using IdentityService.Sdk.Services.User;
@@ -17,6 +18,7 @@ public partial class TicketDetailSupporter : ComponentBase, IAsyncDisposable
     [Inject] private IUIUserContext UserContext { get; set; } = default!;
     [Inject] private ITicketService TicketService { get; set; } = default!;
     [Inject] private IUserService UserService { get; set; } = default!;
+    [Inject] private IGatewayService GatewayService { get; set; } = default!;
     [Inject] private ILogger<TicketDetailSupporter> Logger { get; set; } = default!;
     [Inject] private NavigationManager NavigationManager { get; set; } = default!;
 
@@ -40,26 +42,28 @@ public partial class TicketDetailSupporter : ComponentBase, IAsyncDisposable
         HubService.OnMessageUpdated += HandleMessageUpdated;
         HubService.OnMessageDeleted += HandleMessageDeleted;
 
-        if (Ticket.CustomerId.HasValue)
-            _ = ResolveCustomerNameAsync(Ticket.CustomerId.Value);
-
-        await LoadMessagesAsync();
+        await LoadDetailAsync();
         _ = ConnectHubAsync();
     }
 
-    private async Task LoadMessagesAsync()
+    private async Task LoadDetailAsync()
     {
         _isLoadingMessages = true;
 
-        var result = await MessageSdkService.GetMessagesByTicketIdAsync(Ticket.Id);
-        if (result.IsSuccess && result.Value is not null)
+        var result = await GatewayService.GetTicketDetailAsync(Ticket.Id);
+        if (result.IsSuccess)
         {
-            _messages = result.Value.Items.ToList();
-            await ResolveUserNamesAsync(_messages);
+            _messages = result.Value.Messages;
+            foreach (var (key, name) in result.Value.UserNames)
+                if (Guid.TryParse(key, out var id))
+                    _userNameCache[id] = name;
+
+            if (Ticket.CustomerId.HasValue && _userNameCache.TryGetValue(Ticket.CustomerId.Value, out var customerName))
+                _customerName = customerName;
         }
         else
         {
-            Logger.LogError("TicketDetailSupporter failed to load messages for ticket {TicketId}: {Error}", Ticket.Id, result.Error);
+            Logger.LogError("TicketDetailSupporter failed to load detail for ticket {TicketId}: {Error}", Ticket.Id, result.Error);
         }
 
         _isLoadingMessages = false;
@@ -76,20 +80,6 @@ public partial class TicketDetailSupporter : ComponentBase, IAsyncDisposable
 
         if (HubService.IsConnected)
             _ = HubService.JoinTicketGroupAsync(Ticket.Id);
-    }
-
-    private async Task ResolveCustomerNameAsync(Guid customerId)
-    {
-        try
-        {
-            var result = await UserService.GetUserDetailsAsync(customerId);
-            _customerName = result.IsSuccess ? result.Value.name : null;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Could not resolve customer name for {CustomerId}", customerId);
-        }
-        await InvokeAsync(StateHasChanged);
     }
 
     private async Task SendMessageAsync()

--- a/src/ui/CCP.UI/Program.cs
+++ b/src/ui/CCP.UI/Program.cs
@@ -1,3 +1,4 @@
+using Gateway.Sdk.ServiceDefaults;
 using CCP.ServiceDefaults;
 using CCP.Shared.AuthContext;
 using CCP.Shared.UIContext;
@@ -151,6 +152,11 @@ namespace CCP.UI
             builder.Services.AddChatServiceSdk(
                 builder.Configuration.GetValue<string>("services:chatservice-api:http:0")
                 ?? throw new InvalidOperationException("ChatServiceUrl configuration value is required.")
+                );
+
+            builder.Services.AddGatewayServiceSdk(
+                builder.Configuration.GetValue<string>("services:ccp-gateway:http:0")
+                ?? throw new InvalidOperationException("GatewayServiceUrl configuration value is required.")
                 );
 
             var app = builder.Build();


### PR DESCRIPTION
aggregation endpoints

Add Gateway.Api and Gateway.Sdk projects to centralise cross-service data aggregation, reducing the number of service calls made directly from the UI. Gateway.Api exposes two aggregation endpoints:

GET /gateway/tickets/{id}/detail — fetches ticket, messages, and resolves all user display names in parallel GET /gateway/dashboard/manager — fetches manager stats with team performance names pre-resolved

Gateway.Sdk provides a typed IGatewayService client consumed by the UI, following the same SDK pattern as other services.

Updated TicketDetailManager, TicketDetailSupporter, and SaasDashboardManager to use the Gateway instead of making separate calls to TicketService, MessagingService, and IdentityService.

Fix: service account requests bypassing OrganizationId query filter

Added IsServiceAccount to ICurrentUser and CurrentUser in CCP.Shared

Updated AuthMiddleware to set IsServiceAccount = true when no org claim is present on an authenticated token

Updated TicketDbContext query filter to bypass OrganizationId check for service account callers

Added missing configuration: parameter to

AddMessageServiceSDK and AddIdentityServiceSdk registrations in Gateway.Api/Program.cs so service account token management is correctly initialised